### PR TITLE
Do not escape slashes.

### DIFF
--- a/src/Writer/Version1/Renderer.php
+++ b/src/Writer/Version1/Renderer.php
@@ -71,7 +71,7 @@ class Renderer implements RendererInterface
             }, $hubs);
         }
 
-        return json_encode($result);
+        return json_encode($result, JSON_UNESCAPED_SLASHES);
     }
 
     /**


### PR DESCRIPTION
By default, `json_encode()` escapes forward slashes. Because of this,  the output of *jsonfeed*  is looking a bit cluttered:

```
{"version":"https:\/\/jsonfeed.org\/version\/1",...}
```

This patch adds the `JSON_UNESCAPED_SLASHES` flag to produce a cleaner output. This is also [consistent with the *official* WordPress extension.](https://github.com/manton/jsonfeed-wp/blob/a49d065b705b25a779fee68374a72cec914709fc/feed-template.php#L71)
